### PR TITLE
Fix routing table spec for Clojure 1.10.0-alpha6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,2 @@
 language: clojure
+script: lein test-all

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/weavejester/ataraxy"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
                  [ring/ring-core "1.6.1"]]
   :profiles
   {:dev {:dependencies [[criterium "0.4.3"]]}})

--- a/project.clj
+++ b/project.clj
@@ -6,4 +6,8 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [ring/ring-core "1.6.1"]]
   :profiles
-  {:dev {:dependencies [[criterium "0.4.3"]]}})
+  {:dev {:dependencies [[criterium "0.4.3"]]}
+   :1.10 {:dependencies [[org.clojure/clojure "1.10.0-alpha6"]]}}
+
+  :aliases
+  {"test-all" ["with-profile" "default:+1.10" "test"]})

--- a/src/ataraxy/core.clj
+++ b/src/ataraxy/core.clj
@@ -54,8 +54,15 @@
 (defn- distinct-result-keys? [routing-table]
   (all-distinct? (map :key (conformed-results routing-table))))
 
+(defn- transform-map->list [m]
+  (if (map? m)
+    (apply list (mapcat seq m))
+    ::s/invalid))
+
 (s/def ::routing-table
-  (s/and (s/or :unordered (s/and map?  (s/* (s/spec ::route-result)))
+  (s/and (s/or :unordered (s/and map?
+                                 (s/conformer transform-map->list)
+                                 (s/* ::route-result))
                :ordered   (s/and list? (s/* ::route-result)))
          distinct-result-keys?))
 


### PR DESCRIPTION
The latest Clojure alpha release, `1.10.0-alpha6` includes updated dependencies for:

  * spec.alpha 0.2.168
  * core.specs.alpha 0.2.36

I believe these dependencies were bumped in the previous alpha release for Clojure `1.10.0-alpha5`.

These spec lib updates have resulted in further precision and tightening of spec behaviours, such that the `s/*` macro no longer coerces hash-maps to a seq of key value pairs.

#### Clojure 1.9.0 behaviour
```clojure
(s/explain (s/* vector?)
           {2 5})

;; Success!
;; => nil

(s/conform (s/* vector?)
           {2 5})

;; => [[2 5]]
```

#### Clojure 1.10.0-alpha6 behaviour
```clojure
(s/explain (s/* vector?)
           {2 5})

;; val: {2 5} fails predicate: (or (nil? %) (sequential? %))
```

When ataraxy is used under Clojure `1.10.0-alpha6`, the `:ataraxy.core/routing-table` spec will fail because the old behaviour of `s/*` is used with a map here: https://github.com/weavejester/ataraxy/blob/ac4e441afaf8fa89dcbe93f319659832f7bd9c48/src/ataraxy/core.clj#L58

I am submitting a patch that I've tested to be forwards compatible with Clojure `1.10` from versions `1.10.alpha5` onwards, as well as backwards compatible with the current Clojure `1.9.0` release.
