### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ the default handler, allowing for code like this:
 
 (def handler
   (ataraxy/handler
-    {:routes   {[:get "/hello/" name] [:hello name]}
+    {:routes   '{[:get "/hello/" name] [:hello name]}
      :handlers {:hello hello}}))
 ```
 


### PR DESCRIPTION
Added a missing quote which was needed for the symbol `name` not to resolve to `clojure.core/name`.