### PR TITLE
Fix README - Add missing `require`  for `ataraxy.core`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ requests. See the following section on [syntax](#syntax) for details.
 (def routes '{"/foo" [:foo]})
 ```
 
+Note: In the following examples, we use aliasing:
+```clojure
+(require '[ataraxy.core :as ataraxy])
+```
+
+Let's take a look at routing examples.
+
 We can match a request map to a result with `matches`:
 
 ```clojure


### PR DESCRIPTION
In the current README, `require` for `ataraxy.core` is missing.
I think it is confusing for newbies, because it is difficult for them to find a linkage between  `ataraxy.core` and  `ataraxy` by themselves.

Note: 
I am a non-native English speaker.
Please fix expressions if not appropriate.