### PR TITLE
Add ::unprocessable-entity support

### DIFF
--- a/src/ataraxy/response.clj
+++ b/src/ataraxy/response.clj
@@ -110,6 +110,9 @@
 (defmethod handler/sync-default ::expectation-failed [{[_ body] :ataraxy/result}]
   (-> (->response body) (resp/status 417)))
 
+(defmethod handler/sync-default ::unprocessable-entity [{[_ body] :ataraxy/result}]
+  (-> (->response body) (resp/status 422)))
+
 (defmethod handler/sync-default ::precondition-required [{[_ body] :ataraxy/result}]
   (-> (->response body) (resp/status 428)))
 


### PR DESCRIPTION
422 is commonly used to denote that a request was invalid according to some application-level spec, notably Rails fosters it.

Cheers - V